### PR TITLE
fix: export `multicodec` property

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -138,6 +138,7 @@ const resolveField = (header, field) => {
 }
 
 module.exports = {
+  multicodec: 'zcash-block',
   resolve: resolve,
   tree: tree
 }

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -155,6 +155,13 @@ describe('IPLD format resolver API tree()', () => {
   })
 })
 
+describe('IPLD format resolver API properties', () => {
+  it('should have `multicodec` defined correctly', (done) => {
+    expect(IpldZcash.resolver.multicodec).to.equal('zcash-block')
+    done()
+  })
+})
+
 const verifyPath = (block, path, expected, done) => {
   IpldZcash.resolver.resolve(block, path, (err, value) => {
     expect(err).to.not.exist()


### PR DESCRIPTION
The public `multicodec` property is needed to make it work with js-ipld.