### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 > JavaScript implementation of the [IPLD format spec](https://github.com/ipld/interface-ipld-format) for Zcash blocks.
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)
@@ -22,7 +26,6 @@
   - [Use in a browser with browserify, webpack or any other bundler](#use-in-a-browser-with-browserify-webpack-or-any-other-bundler)
   - [Use in a browser Using a script tag](#use-in-a-browser-using-a-script-tag)
 - [Usage](#usage)
-- [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -75,10 +78,6 @@ IpldZcash.util.deserialize(zcashBlock, (err, dagNode) => {
   console.log(dagNode)
 })
 ```
-
-## Maintainers
-
-[@vmx](https://github.com/vmx)
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipld-zcash",
   "version": "0.1.3",
   "description": "JavaScript implementation of Zcash IPLD formats",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "test": "aegir test",
@@ -26,7 +27,6 @@
   "keywords": [
     "IPFS"
   ],
-  "author": "vmx",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ipld/js-ipld-zcash/issues"


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md