### PR TITLE
fix: add missing async dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-zcash#readme",
   "dependencies": {
+    "async": "^2.6.1",
     "cids": "~0.5.2",
     "dirty-chai": "^2.0.1",
     "multihashes": "~0.4.12",


### PR DESCRIPTION
This dep is used in `src/util.js` but was missing from package.json