### PR TITLE
Move dirty-chai to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   "dependencies": {
     "async": "^2.6.1",
     "cids": "~0.5.2",
-    "dirty-chai": "^2.0.1",
     "multihashes": "~0.4.12",
     "multihashing-async": "~0.5.1",
     "zcash-bitcore-lib": "~0.13.20-rc3"
   },
   "devDependencies": {
     "aegir": "^15.0.0",
-    "chai": "^4.1.2"
+    "chai": "^4.1.2",
+    "dirty-chai": "^2.0.1"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
The "dependency" creates an error message during npm install of any module up the tree (including js-ipfs) because dirty-chai has a peer dependency on chai, which isn't installed. 

All the other ipfs repos have it under devDependencies