### PR TITLE
chore: update Changlelog to match the generated one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="0.4.0"></a>
 # [0.4.0](https://github.com/ipld/js-ipld-zcash/compare/v0.3.0...v0.4.0) (2019-10-29)
 
+### Bug Fixes
+
+* **package:** update multihashing-async to version 0.8.0 ([6a3869d](https://github.com/ipld/js-ipld-zcash/commit/6a3869d))
+
 
 ### Features
 


### PR DESCRIPTION
The Changelog was edited manually, make it match the version that
would've been generated.