### PR TITLE
fix: support deserializing Uint8Arrays

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -5,6 +5,7 @@ const CID = require('cids')
 const multicodec = require('multicodec')
 const multihashes = require('multihashes')
 const multihashing = require('multihashing-async')
+const { Buffer } = require('buffer')
 
 const ZCASH_BLOCK_HEADER_SIZE = 1487
 const CODEC = multicodec.ZCASH_BLOCK
@@ -27,6 +28,11 @@ const serialize = (dagNode) => {
  */
 const deserialize = (binaryBlob) => {
   let deserialized
+
+  if (!Buffer.isBuffer(binaryBlob)) {
+    // zcash only takes Buffers, not Uint8Arrays
+    binaryBlob = Buffer.from(binaryBlob)
+  }
 
   if (binaryBlob.length < ZCASH_BLOCK_HEADER_SIZE) {
     throw new Error(`Zcash block must at least include the ${ZCASH_BLOCK_HEADER_SIZE} header bytes`)

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -86,6 +86,10 @@ describe('IPLD format util API cid()', () => {
       IpldZcash.util.cid(fixtures.blockHeader, { hashAlg: 0xffffff })
     ).to.be.rejectedWith('Unrecognized function code: 16777215')
   })
+
+  it('should deserialize a Uint8Array', () => {
+    IpldZcash.util.deserialize(Uint8Array.from(fixtures.blockHeader))
+  })
 })
 
 const verifyBlock = (header, expected) => {


### PR DESCRIPTION
We've recently started to use Uint8Arrays instead of node Buffers,
but `zcash-block` calls methods on it's input that are only available
on Buffers, so convert binary blobs to Buffers before passing them in
if they are not already Buffers.