### PR TITLE
fix: update to latest cids and uint8array compatible deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,17 +34,14 @@
   "homepage": "https://github.com/ipld/js-ipld-zcash#readme",
   "dependencies": {
     "buffer": "^5.6.0",
-    "cids": "^0.8.3",
-    "multicodec": "^1.0.0",
-    "multihashes": "^1.0.1",
-    "multihashing-async": "^1.0.0",
+    "cids": "^1.0.0",
+    "multicodec": "^2.0.0",
+    "multihashes": "^3.0.1",
+    "multihashing-async": "^2.0.0",
     "zcash-block": "^2.0.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
-    "dirty-chai": "^2.0.1"
+    "aegir": "^25.0.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/util.js
+++ b/src/util.js
@@ -23,7 +23,7 @@ const serialize = (dagNode) => {
 /**
  * Deserialize Zcash block into the internal representation.
  *
- * @param {Buffer} binaryBlob - Binary representation of a Zcash block
+ * @param {Uint8Array} binaryBlob - Binary representation of a Zcash block
  * @returns {ZcashBlock}
  */
 const deserialize = (binaryBlob) => {
@@ -31,7 +31,7 @@ const deserialize = (binaryBlob) => {
 
   if (!Buffer.isBuffer(binaryBlob)) {
     // zcash only takes Buffers, not Uint8Arrays
-    binaryBlob = Buffer.from(binaryBlob)
+    binaryBlob = Buffer.from(binaryBlob, binaryBlob.byteOffset, binaryBlob.byteLength)
   }
 
   if (binaryBlob.length < ZCASH_BLOCK_HEADER_SIZE) {

--- a/test/mod.spec.js
+++ b/test/mod.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multicodec = require('multicodec')
 
 const mod = require('../src')

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const IpldZcash = require('../src/index')
 const helpers = require('./helpers')

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,12 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const chaiAsPromised = require('chai-as-promised')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(chaiAsPromised)
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const multicodec = require('multicodec')
 const { Buffer } = require('buffer')


### PR DESCRIPTION
BREAKING CHANGES:

- `util.cid` returns `CID`s with a breaking API change - see https://github.com/multiformats/js-cid/pull/117 for changes